### PR TITLE
Initialize pinecone package, clean up deprecated ioutil methods, Replace URL with correct GitHub Org URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,24 @@
 dump/.DS_Store
 dump/TDATA/.DS_Store
 .DS_Store
+
+
+# Go related
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module pinecone
+
+go 1.21.5
+
+require github.com/fatih/color v1.16.0
+
+require (
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.14.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/pinecone.go
+++ b/pinecone.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -63,7 +62,7 @@ func downloadJSONData(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func loadJSONData(jsonFilePath, owner, repo, path string, v interface{}, updateFlag bool) error {
@@ -77,7 +76,7 @@ func loadJSONData(jsonFilePath, owner, repo, path string, v interface{}, updateF
 
 		// Check if downloaded JSON is different from existing JSON
 		if _, err := os.Stat(jsonFilePath); err == nil {
-			existingData, err := ioutil.ReadFile(jsonFilePath)
+			existingData, err := os.ReadFile(jsonFilePath)
 			if err != nil {
 				return err
 			}
@@ -90,7 +89,7 @@ func loadJSONData(jsonFilePath, owner, repo, path string, v interface{}, updateF
 
 		// Write the newly downloaded JSON to file
 		fmt.Printf("Updating %s...\n", jsonFilePath)
-		err = ioutil.WriteFile(jsonFilePath, jsonData, 0644)
+		err = os.WriteFile(jsonFilePath, jsonData, 0644)
 		if err != nil {
 			return err
 		}
@@ -104,7 +103,7 @@ func loadJSONData(jsonFilePath, owner, repo, path string, v interface{}, updateF
 		}
 	} else {
 		// Load existing JSON data
-		jsonData, err := ioutil.ReadFile(jsonFilePath)
+		jsonData, err := os.ReadFile(jsonFilePath)
 		if err != nil {
 			return err
 		}
@@ -186,7 +185,7 @@ func checkForContent(directory string) error {
 	return err
 }
 func processDLCContent(subDirDLC string, titleData TitleData, titleID string, directory string) error {
-	subContents, err := ioutil.ReadDir(subDirDLC)
+	subContents, err := os.ReadDir(subDirDLC)
 	if err != nil {
 		return err
 	}
@@ -234,7 +233,7 @@ func processUpdates(subDirUpdates string, titleData TitleData, titleID string, d
 		ignoreList = []string{} // Empty ignore list to prevent panics
 	}
 
-	files, err := ioutil.ReadDir(subDirUpdates)
+	files, err := os.ReadDir(subDirUpdates)
 	if err != nil {
 		return err
 	}
@@ -290,7 +289,7 @@ func processUpdates(subDirUpdates string, titleData TitleData, titleID string, d
 func loadIgnoreList(filepath string) ([]string, error) {
 	var ignoreList []string
 
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +413,7 @@ func main() {
 	}
 	jsonFilePath := "data/id_database.json"
 	jsonDataFolder := "data"
-	jsonURL := "https://api.github.com/repos/OfficialTeamUIX/Pinecone/contents/data/id_database.json"
+	jsonURL := "https://api.github.com/repos/Xbox-Preservation-Project/Pinecone/contents/data/id_database.json"
 
 	// Ensure data folder exists
 	if _, err := os.Stat(jsonDataFolder); os.IsNotExist(err) {
@@ -428,7 +427,7 @@ func main() {
 	if _, err := os.Stat(jsonFilePath); os.IsNotExist(err) {
 		// Prompt for download if JSON file doesn't exist
 		if promptForDownload(jsonURL) {
-			err := loadJSONData(jsonFilePath, "OfficialTeamUIX", "Pinecone", "data/id_database.json", &titles, true)
+			err := loadJSONData(jsonFilePath, "Xbox-Preservation-Project", "Pinecone", "data/id_database.json", &titles, true)
 			if err != nil {
 				fmt.Println("Error downloading data:", err)
 				return
@@ -439,14 +438,14 @@ func main() {
 		}
 	} else if *updateFlag {
 		// Handle manual update
-		err := loadJSONData(jsonFilePath, "OfficialTeamUIX", "Pinecone", "data/id_database.json", &titles, true)
+		err := loadJSONData(jsonFilePath, "Xbox-Preservation-Project", "Pinecone", "data/id_database.json", &titles, true)
 		if err != nil {
 			fmt.Println("Error updating data:", err)
 			return
 		}
 	} else {
 		// Load existing JSON data
-		err := loadJSONData(jsonFilePath, "OfficialTeamUIX", "Pinecone", "data/id_database.json", &titles, false)
+		err := loadJSONData(jsonFilePath, "Xbox-Preservation-Project", "Pinecone", "data/id_database.json", &titles, false)
 		if err != nil {
 			fmt.Println("Error loading data:", err)
 			return


### PR DESCRIPTION
I went through and did several things

1. Initialized the project with `go mod` to make it easier for other people to contribute to the project without jumping through simple setup hoops
2. Added Go related `.gitignore` entries to make sure no one commits a bad file
3. Replaced `ioutil` methods with `io` and `os` calls since `ioutil` has been deprecated since Go 1.16
4. Replaced `OfficialTeamUIX` with `Xbox-Preservation-Project` in the URL calls so it doesn't try to call a bad URL in the future