### PR TITLE
Add Check for `ContentMeta.xbx` inside of DLC directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 dump/.DS_Store
 dump/TDATA/.DS_Store
 .DS_Store
-
+dump/**/
 
 # Go related
 # Binaries for programs and plugins

--- a/pinecone.go
+++ b/pinecone.go
@@ -203,7 +203,7 @@ func processDLCContent(subDirDLC string, titleData TitleData, titleID string, di
 
 		hasContentMetaXbx := false
 		for _, dlcFiles := range subDirContents {
-			if strings.Contains(strings.ToLower(dlcFiles.Name()), "contentmeta.xbx") {
+			if strings.Contains(strings.ToLower(dlcFiles.Name()), "contentmeta.xbx") && !dlcFiles.IsDir() {
 				hasContentMetaXbx = true
 				break
 			}

--- a/pinecone.go
+++ b/pinecone.go
@@ -196,6 +196,23 @@ func processDLCContent(subDirDLC string, titleData TitleData, titleID string, di
 			continue
 		}
 
+		subDirContents, err := os.ReadDir(subContentPath)
+		if err != nil {
+			return err
+		}
+
+		hasContentMetaXbx := false
+		for _, dlcFiles := range subDirContents {
+			if strings.Contains(strings.ToLower(dlcFiles.Name()), "contentmeta.xbx") {
+				hasContentMetaXbx = true
+				break
+			}
+		}
+
+		if !hasContentMetaXbx {
+			continue
+		}
+
 		contentID := strings.ToLower(subContent.Name())
 		if !contains(titleData.ContentIDs, contentID) {
 			printInfo(color.FgRed, "Unknown content found at: %s\n", subContentPath)


### PR DESCRIPTION
This adds a simple check for the `ContentMeta.xbx` file that is present inside of all DLC directories, and skips a directory if it does not have that file.

I also added all subfolders in `/dump` to the gitignore file so I don't upload my test dumps to the repo